### PR TITLE
fix: incorrect filename definition in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,10 +11,10 @@ set(CMAKE_CXX_STANDARD 17)
 # Ajouter les fichiers source
 add_executable(Projet_Poisson
         main.cpp
-        poisson/poisson.cpp
-        poisson/poisson.h
-        fenetre/fenetre.cpp
-        fenetre/fenetre.h
+        Poisson/Poisson.cpp
+        Poisson/Poisson.h
+        Fenetre/Fenetre.cpp
+        Fenetre/Fenetre.h
         Personage/Personnage.cpp
         Personage/Personnage.h
         Personage/var_personnage.h


### PR DESCRIPTION
The following files in the project have their first letter uppercase:
- Fenetre/Fenetre.cpp
- Fenetre/Fenetre.h
- Personnage/Personnage.cpp
- Personnage/Personnage.h

This was not reflected in the CMakeLists.txt file, which used only lowercase filenames.

It probably worked on WSL because WSL is not case-sensitive by default for folders mounted from the Windows host.

Signed-off-by: Florian Bescher <florian.bescher@isen-ouest.yncrea.fr>